### PR TITLE
Datascript back to Clojure data structure transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pom.xml.asc
 output.json
 /assets
 output.txt
+sample-db.edn

--- a/src/static_roam/core.clj
+++ b/src/static_roam/core.clj
@@ -6,7 +6,7 @@
 (defn generate-static-roam!
   [path-to-zip output-dir degree]
   (let [roam-json (utils/read-roam-json-from-zip path-to-zip)
-        database-connection (database/setup-static-roam-db roam-json degree)]
+        database-connection (database/setup-static-roam-block-map roam-json degree)]
     (html-gen/generate-static-roam-html database-connection output-dir)))
 
 (defn -main

--- a/src/static_roam/database.clj
+++ b/src/static_roam/database.clj
@@ -187,15 +187,10 @@
 (pprint/pprint example)
 
 (defn linked-references
-  [block-ds-id conn]
-  (pprint/pprint block-ds-id)
-  (let [the-linked-references (ds/q ;; TODO: this query is wrong. Fix
-                               '[:find ?linked-references
-                                 :in $ ?block-ds-id
-                                 :where
-                                 [?block-ds-id :block/linked-by ?linked-references]]
-                               @conn)]
-    the-linked-references))
+  [block-id block-map]
+  (let [block-props (get block-map block-id)
+        linked-refs (:linked-by block-props)]
+    linked-refs))
 
 (defn degree-explore!
   [current-level max-level conn]
@@ -217,8 +212,8 @@
       nil
       nil)))
 
-(defn mark-content-entities-for-inclusion!
-  [degree conn]
+(defn mark-content-entities-for-inclusion
+  [degree block-map]
   (if (and (int? degree) (>= degree 0))
     (degree-explore! 0 degree conn)
     (doseq [block-ds-id (vec (ds/q '[:find ?block-id
@@ -247,6 +242,6 @@
 (defn setup-static-roam-block-map
   [roam-json degree]
   (let [replicated-roam-block-map (replicate-roam-db roam-json)
-        blocks-tagged-for-inclusion (mark-blocks-for-inclusion! degree replicated-roam-block-map)
+        blocks-tagged-for-inclusion (mark-content-entities-for-inclusion degree replicated-roam-block-map)
         hiccup-for-included-blocks (generate-hiccup-for-included-blocks blocks-tagged-for-inclusion)]
     hiccup-for-included-blocks))

--- a/src/static_roam/database.clj
+++ b/src/static_roam/database.clj
@@ -146,49 +146,9 @@
         block-map-with-links (attach-links-to-block-map links block-map-no-links)]
     block-map-with-links))
 
-(def example
-  (generate-linked-references {"the [[skill level]] of each user grows over time"
-                             {:children '(),
-                              :content "the [[skill level]] of each user grows over time",
-                              :heading -1,
-                              :text-align "",
-                              :entry-point false,
-                              :page true},
-                             "skill level"
-                             {:children '("MYOLydOF1" "5r3u0iI4O"),
-                              :content "skill level",
-                              :heading -1,
-                              :text-align "",
-                              :entry-point false,
-                              :page true},
-                             "MYOLydOF1"
-                             {:children '(),
-                              :content
-                              "There are [[[[individual difference]]s between people in prior [[skill level]]]] before they open up an app",
-                              :heading -1,
-                              :text-align "",
-                              :entry-point false,
-                              :page false},
-                             "5r3u0iI4O"
-                             {:children '(),
-                              :content "[[Problem Text]] [[skill level]]",
-                              :heading -1,
-                              :text-align "",
-                              :entry-point false,
-                              :page false},
-                             "Problem Text"
-                             {:children '(),
-                              :content "Problem Text",
-                              :heading -1,
-                              :text-align "",
-                              :entry-point false,
-                              :page true}}))
-
-(pprint/pprint example)
-
 (defn linked-references
   [block-id block-map]
-  (let [block-props (get block-map block-id)
+  (let [block-props (get block-map block-id "BLOCK DOESN'T EXIST")
         linked-refs (:linked-by block-props)]
     linked-refs))
 
@@ -212,16 +172,16 @@
       nil
       nil)))
 
+(defn- mark-as-included
+  [block-kv]
+  [(first block-kv) (assoc (second block-kv) :included true)])
+
 (defn mark-content-entities-for-inclusion
   [degree block-map]
   (if (and (int? degree) (>= degree 0))
-    (degree-explore! 0 degree conn)
-    (doseq [block-ds-id (vec (ds/q '[:find ?block-id
-                                     :where
-                                     [_ :block/id ?block-id]]
-                                   @conn))]
-      (ds/transact! conn [{:block/id (first block-ds-id)
-                           :block/included true}]))))
+    ;; (degree-explore! 0 degree conn)
+    (println "hello")
+    (into (hash-map) (map mark-as-included block-map))))
 
 (defn generate-hiccup
   [conn]

--- a/src/static_roam/parser.clj
+++ b/src/static_roam/parser.clj
@@ -157,7 +157,7 @@
 
 (defn block-content->hiccup
   "Convert Roam markup to Hiccup"
-  [block-ds-id content conn]
+  [block-ds-id content]
   (vec (map ele->hiccup (parse-to-ast content))))
 
 parsed


### PR DESCRIPTION
Decided to transition away from Datascript and back to using a Clojure hash-map for information about content entities. This is because Datascript was huge overkill for what I'm doing and involved lots of unnecessary state. Figured it would be worth it to transition now so that I don't have to deal with any issues arising from all that state.