### PR TITLE
Linked references and transition away from Datascript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pom.xml.asc
 output.json
 /assets
 output.txt
+sample-db.edn

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 *.html
 output.json
 /assets
+output.txt

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,5 @@
                  [org.clojure/data.json "1.0.0"]
                  [hiccup "1.0.5"]
                  [stasis "2.5.0"]
-                 [datascript "0.18.11"]
                  [instaparse "1.4.10"]]
   :main static-roam.core)

--- a/src/static_roam/core.clj
+++ b/src/static_roam/core.clj
@@ -43,6 +43,7 @@
                    :block/children {:db/cardinality :db.cardinality/many}}
         conn      (ds/create-conn schema)]
     (database/populate-db! roam-json conn)
+    (database/link-blocks! conn)
     (database/mark-blocks-for-inclusion! degree conn)
     (let [db         @conn
           id+content (ds/q '[:find ?id ?content

--- a/src/static_roam/core.clj
+++ b/src/static_roam/core.clj
@@ -98,7 +98,7 @@
                       "./assets/css/main.css"
                       "./assets/js/extra.js"))}
      output-dir)
-    (pprint/pprint conn)))
+    conn))
 
 (defn -main
   [path-to-zip output-dir degree]

--- a/src/static_roam/core.clj
+++ b/src/static_roam/core.clj
@@ -6,8 +6,8 @@
 (defn generate-static-roam!
   [path-to-zip output-dir degree]
   (let [roam-json (utils/read-roam-json-from-zip path-to-zip)
-        database-connection (database/setup-static-roam-block-map roam-json degree)]
-    (html-gen/generate-static-roam-html database-connection output-dir)))
+        static-roam-block-map (database/setup-static-roam-block-map roam-json degree)]
+    (html-gen/generate-static-roam-html static-roam-block-map output-dir)))
 
 (defn -main
   [path-to-zip output-dir degree]

--- a/src/static_roam/core.clj
+++ b/src/static_roam/core.clj
@@ -6,7 +6,7 @@
 (defn generate-static-roam!
   [path-to-zip output-dir degree]
   (let [roam-json (utils/read-roam-json-from-zip path-to-zip)
-        database-connection (database/setup-static-roam-db roam-json degree)]
+        database-connection (database/setup-static-roam-block-map roam-json degree)]
     (html-gen/generate-static-roam-html database-connection output-dir)))
 
 (defn -main

--- a/src/static_roam/core.clj
+++ b/src/static_roam/core.clj
@@ -1,115 +1,13 @@
 (ns static-roam.core
-  (:require [clojure.data.json :as json]
-            [clojure.string :as str-utils]
-            [hiccup.core :as hiccup]
-            [stasis.core :as stasis]
-            [datascript.core :as ds]
-            [static-roam.utils :as utils]
-            [static-roam.parser :as parser]
+  (:require [static-roam.utils :as utils]
             [static-roam.database :as database]
-            [static-roam.templating :as templating]
-            [clojure.pprint :as pprint]))
-
-(defn- metadata-properties
-  [metadata]
-  (into (hash-map) (filter #(= 2 (count %)) (map #(str-utils/split % #":: ") metadata))))
-
-(defn- site-metadata
-  [conn]
-  (let [properties (first (ds/q '[:find ?children
-                                         :where
-                                         [?id :block/id "SR Metadata"]
-                                         [?id :block/children ?children]]
-                                       @conn))
-        metadata (map #(:block/content (ds/entity @conn [:block/id %])) properties)
-        prop-val-dict (metadata-properties metadata)]
-    prop-val-dict))
-
-(defn generate-html
-  [conn output-dir template-fn]
-  (stasis/export-pages
-   (zipmap (utils/html-file-titles
-            (sort-by
-             #(first %)
-             (ds/q '[:find ?included-id ?block-title
-                     :where
-                     [?included-id :block/included true]
-                     [?included-id :block/id ?block-title]]
-                   @conn)))
-           (map #(hiccup/html (template-fn % "../assets/css/main.css" "../assets/js/extra.js"))
-                (map #(templating/block-page-template % conn)
-                     (sort-by
-                      #(first %)
-                      (ds/q '[:find ?included-id ?content
-                              :where
-                              [?included-id :block/included true]
-                              [?included-id :block/content ?content]]
-                            @conn)))))
-   (str output-dir "/pages")))
+            [static-roam.html-generation :as html-gen]))
 
 (defn generate-static-roam!
-  "Takes a ZIP file (`path-to-zip`) of Roam export JSON as input, explores the
-   Roam JSON from the entry point pages up through the `degree` specified (see
-   the 'How It Works' doc for more info), transforms the included pages and
-   blocks to HTML with the specified Hiccup template and CSS, and outputs the
-   resulting HTML to `degree`."
   [path-to-zip output-dir degree]
-  (let [json-path (utils/unzip-roam-json-archive
-                   path-to-zip
-                   (->> path-to-zip
-                        (#(str-utils/split % #"/"))
-                        drop-last
-                        (str-utils/join "/") (#(str % "/"))))
-        roam-json (json/read-str (slurp json-path) :key-fn keyword)
-        database-connection (database/setup-roam-db)]
-    (generate-html conn (str output-dir "/pages") templating/page-hiccup)
-    (stasis/export-pages
-     (zipmap (utils/html-file-titles
-              (sort-by
-               #(first %)
-               (ds/q '[:find ?included-id ?block-title
-                       :where
-                       [?included-id :block/included true]
-                       [?included-id :block/id ?block-title]]
-                     @conn)))
-             (map #(hiccup/html (templating/page-hiccup % "../assets/css/main.css" "../assets/js/extra.js"))
-                  (map #(templating/block-page-template % conn)
-                       (sort-by
-                        #(first %)
-                        (ds/q '[:find ?included-id ?content
-                                :where
-                                [?included-id :block/included true]
-                                [?included-id :block/content ?content]]
-                              @conn)))))
-     (str output-dir "/pages"))
-    (stasis/export-pages
-     {"/index.html" (hiccup/html
-                     (templating/page-index-hiccup
-                      (templating/list-of-page-links
-                       (sort (ds/q '[:find ?included-page-title
-                                     :where
-                                     [?id :block/page true]
-                                     [?id :block/included true]
-                                     [?id :block/id ?included-page-title]]
-                                   @conn)) ".")
-                      "../assets/css/main.css"
-                      "../assets/js/extra.js"))}
-     (str output-dir "/pages"))
-    (stasis/export-pages
-     {"/index.html" (hiccup/html
-                     (templating/home-page-hiccup
-                      (templating/list-of-page-links
-                       (sort (ds/q '[:find ?entry-point-content
-                                     :where
-                                     [?id :block/included true]
-                                     [?id :block/entry-point true]
-                                     [?id :block/content ?entry-point-content]]
-                                   @conn)) "pages" "entry-point-link")
-                      (get (site-metadata conn) "Title")
-                      "./assets/css/main.css"
-                      "./assets/js/extra.js"))}
-     output-dir)
-    database-connection))
+  (let [roam-json (utils/read-roam-json-from-zip path-to-zip)
+        database-connection (database/setup-roam-db roam-json degree)]
+    (html-gen/generate-static-roam-html database-connection output-dir)))
 
 (defn -main
   [path-to-zip output-dir degree]

--- a/src/static_roam/core.clj
+++ b/src/static_roam/core.clj
@@ -7,7 +7,8 @@
             [static-roam.utils :as utils]
             [static-roam.parser :as parser]
             [static-roam.database :as database]
-            [static-roam.templating :as templating]))
+            [static-roam.templating :as templating]
+            [clojure.pprint :as pprint]))
 
 (defn- metadata-properties
   [metadata]
@@ -96,10 +97,8 @@
                       "./assets/css/main.css"
                       "./assets/js/extra.js"))}
      output-dir)
-    conn))
+    (pprint/pprint conn)))
 
 (defn -main
   [path-to-zip output-dir degree]
   (generate-static-roam! path-to-zip output-dir degree))
-
-;; (def conn (-main "/home/thomas/Desktop/RoamExports/robert-public-roam.zip" "." :all))

--- a/src/static_roam/core.clj
+++ b/src/static_roam/core.clj
@@ -6,7 +6,7 @@
 (defn generate-static-roam!
   [path-to-zip output-dir degree]
   (let [roam-json (utils/read-roam-json-from-zip path-to-zip)
-        database-connection (database/setup-roam-db roam-json degree)]
+        database-connection (database/setup-static-roam-db roam-json degree)]
     (html-gen/generate-static-roam-html database-connection output-dir)))
 
 (defn -main

--- a/src/static_roam/database.clj
+++ b/src/static_roam/database.clj
@@ -10,6 +10,10 @@
     (:title block-json)
     (:uid block-json)))
 
+(defn get-properties-for-block-id
+  [block-id block-map]
+  (get block-map block-id))
+
 (defn- get-block-properties
   [block-json]
   {
@@ -140,7 +144,7 @@
         block-map-with-links (attach-links-to-block-map links block-map-no-links)]
     block-map-with-links))
 
-(defn linked-references
+(defn get-linked-references
   [block-id block-map]
   (let [block-props (get block-map block-id "BLOCK DOESN'T EXIST")
         linked-refs (:linked-by block-props)]

--- a/src/static_roam/database.clj
+++ b/src/static_roam/database.clj
@@ -33,24 +33,12 @@
         [?entity-id :block/content ?content]]
       @db-conn)
 
-     find-content-entities-in-string
-     (fn [string]
-       (re-seq #"\[\[.*?\]\]|\(\(.*?\)\)" string))
-
-     remove-heading-parens
-     (fn [strings]
-       (map
-        #(if (= "(((" (subs % 0 3))
-           (subs % 1)
-           %)
-        strings))
-
      clean-content-entities
      (fn [string]
        (let [content-entities-found
-             (find-content-entities string)
+             (utils/find-content-entities-in-string string)
              extra-paren-removed
-             (remove-heading-params content-entities-found)
+             (utils/remove-heading-params content-entities-found)
              cleaned-content-entities
              (map utils/remove-double-delimiters extra-paren-removed)]
          page-and-block-names))
@@ -140,9 +128,9 @@
   [roam-json degree]
   (let [schema {:block/id       {:db/unique :db.unique/identity}
                 :block/children {:db/cardinality :db.cardinality/many}}
-        conn (ds/create-conn schema)]
-    (populate-db! roam-json conn)
-    (link-blocks! conn)
-    (mark-blocks-for-inclusion! degree conn)
-    (generate-hiccup conn)
-    conn))
+        db-conn (ds/create-conn schema)]
+    (populate-db! roam-json db-conn)
+    (link-blocks! db-conn)
+    (mark-blocks-for-inclusion! degree db-conn)
+    (generate-hiccup db-conn)
+    db-conn))

--- a/src/static_roam/database.clj
+++ b/src/static_roam/database.clj
@@ -74,7 +74,7 @@
   (let [transactions (generate-transactions-for-linking-blocks references)]
     (ds/transact! db-conn (flatten transactions))))
 
-(defn generate-linked-references!
+(defn- generate-linked-references!
   [db-conn]
   (let
     [entity-id-and-reference-ids (get-entity-id-content-pairs db-conn)
@@ -84,7 +84,8 @@
 
 (defn linked-references
   [block-ds-id conn]
-  (let [the-linked-references (ds/q
+  (pprint/pprint block-ds-id)
+  (let [the-linked-references (ds/q ;; TODO: this query is wrong. Fix
                                '[:find ?linked-references
                                  :in $ ?block-ds-id
                                  :where

--- a/src/static_roam/database.clj
+++ b/src/static_roam/database.clj
@@ -187,15 +187,10 @@
 (pprint/pprint example)
 
 (defn linked-references
-  [block-ds-id conn]
-  (pprint/pprint block-ds-id)
-  (let [the-linked-references (ds/q ;; TODO: this query is wrong. Fix
-                               '[:find ?linked-references
-                                 :in $ ?block-ds-id
-                                 :where
-                                 [?block-ds-id :block/linked-by ?linked-references]]
-                               @conn)]
-    the-linked-references))
+  [block-id block-map]
+  (let [block-props (get block-map block-id)
+        linked-refs (:linked-by block-props)]
+    linked-refs))
 
 (defn degree-explore!
   [current-level max-level conn]
@@ -217,8 +212,8 @@
       nil
       nil)))
 
-(defn mark-content-entities-for-inclusion!
-  [degree conn]
+(defn mark-content-entities-for-inclusion
+  [degree block-map]
   (if (and (int? degree) (>= degree 0))
     (degree-explore! 0 degree conn)
     (doseq [block-ds-id (vec (ds/q '[:find ?block-id
@@ -247,6 +242,6 @@
 (defn setup-static-roam-block-map
   [roam-json degree]
   (let [replicated-roam-block-map (replicate-roam-db roam-json)
-        blocks-tagged-for-inclusion (mark-blocks-for-inclusion! degree replicated-roam-block-map)
+        blocks-tagged-for-inclusion (mark-content-entities-for-inclusion degree replicated-roam-block-map)
         hiccup-for-included-blocks (generate-hiccup-for-included-blocks blocks-tagged-for-inclusion)]
     hiccup-for-included-blocks))

--- a/src/static_roam/database.clj
+++ b/src/static_roam/database.clj
@@ -137,7 +137,7 @@
     (ds/transact! conn transactions)))
 
 (defn setup-roam-db
-  [roam-json]
+  [roam-json degree]
   (let [schema {:block/id       {:db/unique :db.unique/identity}
                 :block/children {:db/cardinality :db.cardinality/many}}
         conn (ds/create-conn schema)]

--- a/src/static_roam/database.clj
+++ b/src/static_roam/database.clj
@@ -20,6 +20,13 @@
                             :block/linked-by []}])
     (populate-db! (:children block) db-conn)))
 
+(defn link-blocks!
+  [db-conn]
+  ;; go through every block's content
+  ;; find all references to other blocks in the content
+  ;; for each of those references, change the `linked-by` property of the referenced block to include the entity ID of the referencing block
+  )
+
 (defn degree-explore!
   [current-level max-level conn]
   (if (= current-level 0)

--- a/src/static_roam/database.clj
+++ b/src/static_roam/database.clj
@@ -17,18 +17,8 @@
                             :block/page (if (:title block)
                                           true
                                           false)
-                            :block/refers-to []}])
+                            :block/linked-by []}])
     (populate-db! (:children block) db-conn)))
-
-(defn linked-references
-  [block-ds-id conn]
-   (ds/q '[:find ?blocks-that-link-here ?blocks-content
-           :in $ ?block-ds-id
-           :where
-           [?block-ds-id :block/id ?block-id]
-           [?blocks-that-link-here :block/refers-to ?block-id]
-           [?blocks-that-link-here :block/content ?blocks-content]]
-         @conn block-ds-id))
 
 (defn degree-explore!
   [current-level max-level conn]

--- a/src/static_roam/database.clj
+++ b/src/static_roam/database.clj
@@ -146,49 +146,9 @@
         block-map-with-links (attach-links-to-block-map links block-map-no-links)]
     block-map-with-links))
 
-(def example
-  (generate-linked-references {"the [[skill level]] of each user grows over time"
-                             {:children '(),
-                              :content "the [[skill level]] of each user grows over time",
-                              :heading -1,
-                              :text-align "",
-                              :entry-point false,
-                              :page true},
-                             "skill level"
-                             {:children '("MYOLydOF1" "5r3u0iI4O"),
-                              :content "skill level",
-                              :heading -1,
-                              :text-align "",
-                              :entry-point false,
-                              :page true},
-                             "MYOLydOF1"
-                             {:children '(),
-                              :content
-                              "There are [[[[individual difference]]s between people in prior [[skill level]]]] before they open up an app",
-                              :heading -1,
-                              :text-align "",
-                              :entry-point false,
-                              :page false},
-                             "5r3u0iI4O"
-                             {:children '(),
-                              :content "[[Problem Text]] [[skill level]]",
-                              :heading -1,
-                              :text-align "",
-                              :entry-point false,
-                              :page false},
-                             "Problem Text"
-                             {:children '(),
-                              :content "Problem Text",
-                              :heading -1,
-                              :text-align "",
-                              :entry-point false,
-                              :page true}}))
-
-(pprint/pprint example)
-
 (defn linked-references
   [block-id block-map]
-  (let [block-props (get block-map block-id)
+  (let [block-props (get block-map block-id "BLOCK DOESN'T EXIST")
         linked-refs (:linked-by block-props)]
     linked-refs))
 
@@ -212,16 +172,16 @@
       nil
       nil)))
 
+(defn- mark-as-included
+  [block-kv]
+  [(first block-kv) (assoc (second block-kv) :included true)])
+
 (defn mark-content-entities-for-inclusion
   [degree block-map]
   (if (and (int? degree) (>= degree 0))
-    (degree-explore! 0 degree conn)
-    (doseq [block-ds-id (vec (ds/q '[:find ?block-id
-                                     :where
-                                     [_ :block/id ?block-id]]
-                                   @conn))]
-      (ds/transact! conn [{:block/id (first block-ds-id)
-                           :block/included true}]))))
+    ;; (degree-explore! 0 degree conn)
+    (println "hello")
+    (into (hash-map) (map mark-as-included block-map))))
 
 (defn generate-hiccup
   [conn]

--- a/src/static_roam/database.clj
+++ b/src/static_roam/database.clj
@@ -54,12 +54,21 @@
   [(first pair)
    (clean-content-entities (second pair))])
 
+(defn- generate-transactions-for-linking-blocks
+  [references])
+
+(defn- transact-linked-blocks!
+  [db-conn references]
+  (let [transactions (generate-transactions-for-linking-blocks references)]
+    (ds/transact! db-conn transactions)))
+
 (defn link-blocks!
   [db-conn]
   (let
     [entity-id-and-content-entities (get-entity-id-content-pairs db-conn)
      cleaned-references (map clean-pair entity-id-and-content-entities)
-     broken-references-removed (map filter-broken-references cleaned-references)]))
+     broken-references-removed (map filter-broken-references cleaned-references)]
+    (transact-linked-blocks! db-conn broken-references-removed)))
 
 (defn linked-references
   [block-ds-id conn])

--- a/src/static_roam/html_generation.clj
+++ b/src/static_roam/html_generation.clj
@@ -1,0 +1,87 @@
+(ns static-roam.html-generation)
+
+(defn- metadata-properties
+  [metadata]
+  (into (hash-map) (filter #(= 2 (count %)) (map #(str-utils/split % #":: ") metadata))))
+
+(defn- site-metadata
+  [conn]
+  (let [properties (first (ds/q '[:find ?children
+                                  :where
+                                  [?id :block/id "SR Metadata"]
+                                  [?id :block/children ?children]]
+                                @conn))
+        metadata (map #(:block/content (ds/entity @conn [:block/id %])) properties)
+        prop-val-dict (metadata-properties metadata)]
+    prop-val-dict))
+
+(defn generate-pages-html
+  [conn output-dir]
+  (let [html-file-names (utils/html-file-titles
+                         (sort-by
+                          #(first %)
+                          (ds/q '[:find ?included-id ?block-title
+                                  :where
+                                  [?included-id :block/included true]
+                                  [?included-id :block/id ?block-title]]
+                                @conn)))
+        generated-html (map #(hiccup/html (templating/page-hiccup % "../assets/css/main.css" "../assets/js/extra.js"))
+                            (map #(templating/block-page-template % conn)
+                                 (sort-by
+                                  #(first %)
+                                  (ds/q '[:find ?included-id ?content
+                                          :where
+                                          [?included-id :block/included true]
+                                          [?included-id :block/content ?content]]
+                                        @conn))))
+        file-name-to-content (zipmap
+                              html-file-names
+                              generated-html)]
+    (stasis/export-pages
+     file-name-to-content
+     output-dir)))
+
+(defn generate-index-of-pages-html
+  [conn output-dir]
+  (let [html-file-name "/index.html"
+        generated-html (hiccup/html
+                        (templating/page-index-hiccup
+                         (templating/list-of-page-links
+                          (sort (ds/q '[:find ?included-page-title
+                                        :where
+                                        [?id :block/page true]
+                                        [?id :block/included true]
+                                        [?id :block/id ?included-page-title]]
+                                      @conn)) ".")
+                         "../assets/css/main.css"
+                         "../assets/js/extra.js"))
+        file-name-to-content {html-file-name generated-html}]
+    (stasis/export-pages
+     file-name-to-content
+     output-dir)))
+
+(defn generate-home-page-html
+  [conn output-dir]
+  (let [html-file-name "/index.html"
+        generated-html (hiccup/html
+                        (templating/home-page-hiccup
+                         (templating/list-of-page-links
+                          (sort (ds/q '[:find ?entry-point-content
+                                        :where
+                                        [?id :block/included true]
+                                        [?id :block/entry-point true]
+                                        [?id :block/content ?entry-point-content]]
+                                      @conn)) "pages" "entry-point-link")
+                         (get (site-metadata conn) "Title")
+                         "./assets/css/main.css"
+                         "./assets/js/extra.js"))
+        file-name-to-content {html-file-name generated-html}]
+    (stasis/export-pages
+     file-name-to-content
+     output-dir)))
+
+(defn generate-static-roam-html
+  [conn output-dir]
+  (generate-pages-html database-connection (str output-dir "/pages"))
+  (generate-index-of-pages-html database-connection (str output-dir "/pages"))
+  (generate-home-page-html database-connection output-dir))

--- a/src/static_roam/html_generation.clj
+++ b/src/static_roam/html_generation.clj
@@ -1,4 +1,10 @@
-(ns static-roam.html-generation)
+(ns static-roam.html-generation
+  (:require [clojure.string :as str-utils]
+            [datascript.core :as ds]
+            [static-roam.utils :as utils]
+            [hiccup.core :as hiccup]
+            [static-roam.templating :as templating]
+            [stasis.core :as stasis]))
 
 (defn- metadata-properties
   [metadata]
@@ -82,6 +88,6 @@
 
 (defn generate-static-roam-html
   [conn output-dir]
-  (generate-pages-html database-connection (str output-dir "/pages"))
-  (generate-index-of-pages-html database-connection (str output-dir "/pages"))
-  (generate-home-page-html database-connection output-dir))
+  (generate-pages-html conn (str output-dir "/pages"))
+  (generate-index-of-pages-html conn (str output-dir "/pages"))
+  (generate-home-page-html conn output-dir))

--- a/src/static_roam/parser.clj
+++ b/src/static_roam/parser.clj
@@ -157,7 +157,7 @@
 
 (defn block-content->hiccup
   "Convert Roam markup to Hiccup"
-  [block-ds-id content conn]
+  [block-ds-id content]
   (vec (map ele->hiccup (parse-to-ast content))))
 
 parsed

--- a/src/static_roam/utils.clj
+++ b/src/static_roam/utils.clj
@@ -1,7 +1,8 @@
 (ns static-roam.utils
   (:require [me.raynes.fs :as fs]
             [clojure.java.io :as io]
-            [clojure.string :as str-utils])
+            [clojure.string :as str-utils]
+            [clojure.data.json :as json])
   (:import (java.util.zip ZipFile)))
 
 (defn unzip-roam-json

--- a/src/static_roam/utils.clj
+++ b/src/static_roam/utils.clj
@@ -71,7 +71,7 @@
 (defn html-file-titles
   [page-titles]
   (let [page-titles-vec (vec page-titles)]
-    (map #(subs (page-title->html-file-title % :case-sensitive) 1) (map second page-titles-vec))))
+    (map #(subs (page-title->html-file-title % :case-sensitive) 1) page-titles-vec)))
 
 (defn page-link-from-title
   "Given a page and a directory for the page to go in, create Hiccup that contains the link to the HTML of that page"

--- a/src/static_roam/utils.clj
+++ b/src/static_roam/utils.clj
@@ -71,3 +71,14 @@
    [:a {:class link-class
         :href (str dir (subs (page-title->html-file-title block-content :case-sensitive) 1))}
     block-content]))
+
+(defn read-roam-json-from-zip
+  [path-to-zip]
+  (let [json-path (unzip-roam-json-archive
+                   path-to-zip
+                   (->> path-to-zip
+                        (#(str-utils/split % #"/"))
+                        drop-last
+                        (str-utils/join "/") (#(str % "/"))))
+        roam-json (json/read-str (slurp json-path) :key-fn keyword)]
+    roam-json))


### PR DESCRIPTION
Linked references now work. I also transitioned back to using plain Clojure data structures for keeping track of blocks and their properties. Reasons for this are in [this](https://github.com/TomLisankie/static-roam/pull/5) PR.